### PR TITLE
Fix so $CF works inside Atom terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ This repository contains Bash scripts which are intended to make life as a softw
 
     trap '
       if [ "x$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "xtrue" ]; then
-        export CF=`current-feature`
+        CURRENT_FEATURE=$(git symbolic-ref -q HEAD)
+        CURRENT_FEATURE=${CURRENT_FEATURE##refs/heads/}
+        CURRENT_FEATURE=${CURRENT_FEATURE:-HEAD}
+
+        export CF=$CURRENT_FEATURE
+        echo "CURRENT FEATURE: $CF"
       fi
     ' DEBUG
     


### PR DESCRIPTION
There was a problem running tests inside of Atom.  This fixes that.

Use manual commands, rather than aliases, inside of .bashrc
